### PR TITLE
fix: change font size on crafting machine

### DIFF
--- a/src/craftingmachine.ts
+++ b/src/craftingmachine.ts
@@ -414,7 +414,7 @@ export class CraftingMachine {
       8,
       8,
       ItemIcons.Empty,
-      1.0,
+      1.5,
       true,
       true
     )


### PR DESCRIPTION
-Wonder Coins font was smaller than other elements